### PR TITLE
Changes to STRUCTUREDMAT, skeleton of VANDERMAT.

### DIFF
--- a/@circulantmat/circulantmat.m
+++ b/@circulantmat/circulantmat.m
@@ -26,7 +26,7 @@ classdef circulantmat < toeplitzmat
         function C = circulantmat(varargin)
             % The main toeplitzmat constructor!
             
-            % Error out if no arguments given
+            % Initialize empty TOEPLITZMAT
             if ( (nargin == 0) )
                 error('STRUCTMATS:CIRCULANTMAT:constructor:none', ...
                 'Cannot construct a Ciruclant matrix with no inputs');

--- a/@diagonalstructure/and.m
+++ b/@diagonalstructure/and.m
@@ -1,5 +1,5 @@
 function h = and(T,G)
-%|  Pointwise logical and for DIAGONALSTRUCTURE objects
+%&  Pointwise logical and for DIAGONALSTRUCTURE objects
 %   T and g can be DIAGONALSTRUCTUREs or scalars
 %   behaves the same as & for matrices in MATLAB
 

--- a/@diagonalstructure/horzcat.m
+++ b/@diagonalstructure/horzcat.m
@@ -1,5 +1,5 @@
 function C = horzcat(varargin)
-%HORZCAT Horizontal Concatenation for TOEPLITZMAT objects
+%HORZCAT Horizontal Concatenation for DIAGONALSTRUCTURE objects
   
 % This needs to be overloaded
 error("OVERLOAD HORZCAT")

--- a/@diagonalstructure/mrdivide.m
+++ b/@diagonalstructure/mrdivide.m
@@ -1,6 +1,6 @@
 function h = mrdivide(T, G)
-%MRDIVIDE Matrix Right Divide for TOEPLITZMAT objects.
-%   T and G can be TOEPLITZMATs, scalars, or matrices
+%MRDIVIDE Matrix Right Divide for DIAGONALSTRUCTURE objects.
+%   T and G can be DIAGONALSTRUCTUREs, scalars, or matrices
 %
 %   The code below is just a placeholder!
 

--- a/@diagonalstructure/subsasgn.m
+++ b/@diagonalstructure/subsasgn.m
@@ -1,6 +1,6 @@
 function h = subsasgn(T, S, b)
 %SUBSASGN sets the part of a DIAGONALSTRUCTURE object by referenced subscript.
-%   The result may or may not itself be Toeplitz
+%   The result may or may not itself be Diagonally structured
 
 % Basic implementation that does not take advantage of structure.
 % The way that this will be efficiently overloaded depends on the type

--- a/@diagonalstructure/subsref.m
+++ b/@diagonalstructure/subsref.m
@@ -1,6 +1,6 @@
 function h = subsref(T, S)
 %SUBSREF gets the part of a DIAGONALSTRUCTURE object by referenced subscript.
-%   The result may or may not itself be Toeplitz
+%   The result may or may not itself be Diagonally structured
 
 % Basic implementation that does not take advantage of structure.
 % The way that this will be efficiently overloaded depends on the type

--- a/@hankelmat/constructor.m
+++ b/@hankelmat/constructor.m
@@ -48,8 +48,8 @@ function H = constructor(H, varargin)
 
 %ERROR (i): Too few args
 if(numel(varargin) == 0)
-    error('STRUCTMATS:HANKELMAT:constructor:toofewargs', newline, ...
-            'Too few (0) arguments passed in to construct Hankel matrix');  
+    error(['STRUCTMATS:HANKELMAT:constructor:toofewargs', newline, ...
+            'Too few (0) arguments passed in to construct Hankel matrix']);  
         
 % ERROR (ii)
 elseif( numel(varargin) > 2)
@@ -64,8 +64,8 @@ hc = varargin{1};
 
 % ERROR (iv): Bad input type (non-vector)
 if(~isvector(hc))
-    error('STRUCTMATS:HANKELMAT:constructor:badinput', newline, ...
-            'Input for first-column is not a vector.');
+    error(['STRUCTMATS:HANKELMAT:constructor:badinput', newline, ...
+            'Input for first-column is not a vector.']);
 
 % ERROR (iv): Bad input type (uninterpretable)
 elseif((~isnumeric(hc) && ~islogical(hc)))

--- a/@hankelmat/hankelmat.m
+++ b/@hankelmat/hankelmat.m
@@ -26,8 +26,8 @@ classdef hankelmat < diagonalstructure
             
             % Error out if no arguments given
             if ( (nargin == 0) )
-                H.hc = [];
-                H.hr = [];
+                error(['STRUCTMATS:HANKELMAT:constructor:toofewargs', newline, ...
+                   'Too few (0) arguments passed in to construct Hankel matrix']);  
             % Call the constructor, all the work is done here:
             else
                 H = constructor(H, varargin{:});

--- a/@structuredmat/and.m
+++ b/@structuredmat/and.m
@@ -1,0 +1,10 @@
+function h = and(A,B)
+%&  Pointwise logical and for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as & for matrices in MATLAB
+
+warning(['Using Naive implementation of & for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = and(full(A), full(B));
+end

--- a/@structuredmat/ctranspose.m
+++ b/@structuredmat/ctranspose.m
@@ -1,0 +1,9 @@
+function v = ctranspose(A)
+%CTRANSPOSE Conjugate Transpose for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of CTRANSPOSE for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+v = ctranspose(full(A));
+end
+

--- a/@structuredmat/eq.m
+++ b/@structuredmat/eq.m
@@ -1,0 +1,10 @@
+function h = eq(A,B)
+%==  Pointwise equal to for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as == for matrices in MATLAB
+
+warning(['Using Naive implementation of == for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+eq(full(A),full(B));
+end

--- a/@structuredmat/flip.m
+++ b/@structuredmat/flip.m
@@ -1,0 +1,8 @@
+function v = flip(A)
+%CTRANSPOSE Up-down flip for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of FLIP for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+v = flip(full(A));
+end

--- a/@structuredmat/fliplr.m
+++ b/@structuredmat/fliplr.m
@@ -1,0 +1,8 @@
+function v = fliplr(A)
+%CTRANSPOSE Left-right flip for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of FLIPLR for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+v = flip(full(A));
+end

--- a/@structuredmat/ge.m
+++ b/@structuredmat/ge.m
@@ -1,0 +1,10 @@
+function h = ge(A,B)
+%>=  Pointwise greater than or equal to for STRUCTUREDMAT objects
+%   T and g can be STRUCTUREDMATs or scalars
+%   behaves the same as >= for matrices in MATLAB
+
+warning(['Using Naive implementation of >= for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = ge(full(A), full(B));
+end

--- a/@structuredmat/gt.m
+++ b/@structuredmat/gt.m
@@ -1,0 +1,10 @@
+function h = gt(A,B)
+%>  Pointwise greater than for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as > for matrices in MATLAB
+
+warning(['Using Naive implementation of > for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = gt(full(A), full(B));
+end

--- a/@structuredmat/horzcat.m
+++ b/@structuredmat/horzcat.m
@@ -1,0 +1,8 @@
+function C = horzcat(varargin)
+%HORZCAT Horizontal Concatenation for STRUCTUREDMAT objects
+  
+warning(['Using Naive implementation of HORZCAT.', ...
+        'This should be overloaded to take advantage of the structures!']);
+C = [full horzcat(varargin{2:end})];
+end
+

--- a/@structuredmat/ldivide.m
+++ b/@structuredmat/ldivide.m
@@ -1,0 +1,13 @@
+function h = ldivide(A, B)
+%.\   Pointwise STRUCTUREDMAT left divide
+%   A .\ B pointwise divides A by B. 
+%   A and B can be scalars or Matrices or STRUCTUREDMATs
+
+% Simply reuse rdivide, with the proper call
+%   i.e.    A .\ B = B ./ A
+warning(['Using Naive implementation of .\ for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = rdivide(B,A);
+end
+

--- a/@structuredmat/le.m
+++ b/@structuredmat/le.m
@@ -1,0 +1,10 @@
+function h = le(A,B)
+%<=  Pointwise less than or equal to for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as <= for matrices in MATLAB
+
+warning(['Using Naive implementation of <= for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = le(full(A),full(B));
+end

--- a/@structuredmat/lt.m
+++ b/@structuredmat/lt.m
@@ -1,0 +1,10 @@
+function h = lt(A,B)
+%<  Pointwise less than for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as < for matrices in MATLAB
+
+warning(['Using Naive implementation of < for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = lt(full(A),full(B));
+end

--- a/@structuredmat/minus.m
+++ b/@structuredmat/minus.m
@@ -1,0 +1,11 @@
+function h = minus(A, B)
+%-  Minus for STRUCTUREDMAT objects
+%  A - B subtracts B from A. 
+%  A and B can be scalars or matrices or STRUCTUREDMATs
+
+warning(['Using Naive implementation of > for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = minus(full(A),full(B));
+end
+

--- a/@structuredmat/mldivide.m
+++ b/@structuredmat/mldivide.m
@@ -1,0 +1,10 @@
+function h = mldivide(A, B)
+%MLDIVIDE Matrix Left Divide for STRUCTUREDMAT objects.
+%   A and B can be STRUCTUREDMATs, scalars, or matrices
+
+warning(['Using Naive implementation of \ for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = mldivide(full(A),full(B));
+end
+

--- a/@structuredmat/mpower.m
+++ b/@structuredmat/mpower.m
@@ -1,0 +1,10 @@
+function h = mpower(A,B)
+%MPOWER Matrix Power for STRUCTUREDMAT objects.
+%   A and B can be STRUCTUREDMATs, scalars, or matrices
+
+warning(['Using Naive implementation of ^ for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = mpower(full(A),full(B));
+end
+

--- a/@structuredmat/mrdivide.m
+++ b/@structuredmat/mrdivide.m
@@ -1,0 +1,10 @@
+function h = mrdivide(A, B)
+%MRDIVIDE Matrix Right Divide for STRUCTUREMAT objects.
+%   A and B can be STRUCTUREDMATs, scalars, or matrices
+
+warning(['Using Naive implementation of / for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = mrdivide(full(A),full(B));
+end
+

--- a/@structuredmat/mtimes.m
+++ b/@structuredmat/mtimes.m
@@ -1,0 +1,9 @@
+function h = mtimes(A, B)
+%MTIMES Matrix Times for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of * for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = mtimes(full(A),full(B));
+end
+

--- a/@structuredmat/ne.m
+++ b/@structuredmat/ne.m
@@ -1,0 +1,10 @@
+function h = ne(A,B)
+%~=  Pointwise not equal to for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as ~= for matrices in MATLAB
+
+warning(['Using Naive implementation of ~= for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = ne(full(A), full(B));
+end

--- a/@structuredmat/not.m
+++ b/@structuredmat/not.m
@@ -1,0 +1,10 @@
+function h = not(A)
+%~  Pointwise logical not for STRUCTUREDMAT objects
+%   A is a STRUCTUREDMAT
+%   behaves the same as ~ for matrices in MATLAB
+
+warning(['Using Naive implementation of ~ for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+h = not(full(A));
+end

--- a/@structuredmat/or.m
+++ b/@structuredmat/or.m
@@ -1,0 +1,10 @@
+function h = or(A,B)
+%|  Pointwise logical or for STRUCTUREDMAT objects
+%   A and B can be STRUCTUREDMATs or scalars
+%   behaves the same as | for matrices in MATLAB
+
+warning(['Using Naive implementation of | for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = or(full(A),full(B));
+end

--- a/@structuredmat/plus.m
+++ b/@structuredmat/plus.m
@@ -1,0 +1,11 @@
+function h = plus(A, B)
+%+   Plus for STRUCTUREDMAT objects
+%  A + B adds A and B. 
+%  A and B can be scalars or Matrices or STRUCTUREDMATs
+
+warning(['Using Naive implementation of + for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = plus(full(A),full(B));
+end
+

--- a/@structuredmat/power.m
+++ b/@structuredmat/power.m
@@ -1,0 +1,11 @@
+function h = power(A, B)
+%.^  Pointwise power for STRUCTUREDMAT objects
+%  A .^ B raies A to the B, pointwise. 
+%  A and B can be scalars or Matrices or STRUCTUREDMATs
+
+warning(['Using Naive implementation of .^ for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = power(full(A),full(B));
+end
+

--- a/@structuredmat/rdivide.m
+++ b/@structuredmat/rdivide.m
@@ -1,0 +1,11 @@
+function h = rdivide(A, B)
+%./   Pointwise STRUCTUREDMAT right divide
+%   A ./ B pointwise divides A by B. 
+%   A and B can be scalars or matrices or STRUCTUREDMATs
+
+warning(['Using Naive implementation of ./ for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = rdivide(full(A),full(B));
+end
+

--- a/@structuredmat/size.m
+++ b/@structuredmat/size.m
@@ -1,0 +1,8 @@
+function v = size(A)
+%SIZE Size for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of SIZE for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+v = size(full(A));
+

--- a/@structuredmat/structuredmat.m
+++ b/@structuredmat/structuredmat.m
@@ -11,11 +11,28 @@ classdef (Abstract) structuredmat
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %% CLASS METHODS
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    % Abstract methods, these absolutely NEED to be overloaded in
+    % subclasses.
     methods (Abstract)
 
         % full should cast to a regular MATLAB matrix
         r = full(obj1);
-        
+
+        % These need to be overloaded because of . indexing
+        r = subsref(obj1,S);
+        r = subsasgn(obj1,S,B)
+    end
+
+    % Non-abstract methods that probably should not be overloaded
+    methods
+        % overload the end function for subindexing
+        r = end(obj1,k,n);
+    end
+
+    % Methods with naive implementation at this level. Most, if not all, of
+    % these should be overloaded to make use of the underlying structures.
+    methods
         % overload the logic and comparison operators
         r = and(obj1,obj2);
         r = or(obj1,obj2);
@@ -42,8 +59,7 @@ classdef (Abstract) structuredmat
         r = mldivide(obj1,obj2);
         r = mrdivide(obj1,obj2);
 
-        % overload the subindexing and concatenation
-        r = subsref(obj1,obj2);
+        % overload concatenation
         r = horzcat(obj1,obj2);
         r = vertcat(obj1,obj2);
         
@@ -55,12 +71,6 @@ classdef (Abstract) structuredmat
 
         % overload the size function
         r = size(obj1);
-    end
-
-    % Non-abstract methods
-    methods
-        % overload the end function for subindexing
-        r = end(obj1,k,n);
     end
 end
 

--- a/@structuredmat/times.m
+++ b/@structuredmat/times.m
@@ -1,0 +1,10 @@
+function h = times(A, B)
+%.*   Pointwise multiplication for STRUCTUREDMAT objects
+%   A .* B pointwise multiplies A and B. 
+%   A and B can be scalars or Matrices or STRUCTUREDMATs
+
+warning(['Using Naive implementation of .* for inputs of type %s and %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+h = times(full(A),full(B));
+end

--- a/@structuredmat/transpose.m
+++ b/@structuredmat/transpose.m
@@ -1,0 +1,9 @@
+function v = ctranspose(A)
+%CTRANSPOSE Conjugate Transpose for STRUCTUREDMAT objects
+
+warning(['Using Naive implementation of TRANSPOSE for input of type %s.', ...
+           'This should be overloaded to take advantage of the structure!'], ...
+           class(A));
+v = transpose(full(A));
+end
+

--- a/@structuredmat/uminus.m
+++ b/@structuredmat/uminus.m
@@ -1,0 +1,10 @@
+function h = uminus(A)
+%-A  Unary Minus for STRUCTUREDMAT objects
+%   -A negates A pointwise, where A is a STRUCTUREDMAT object
+
+warning(['Using Naive implementation of uminus (-A) for input of type %s.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A));
+h = -1 .* A;
+end
+

--- a/@structuredmat/uplus.m
+++ b/@structuredmat/uplus.m
@@ -1,0 +1,6 @@
+function h = uplus(A)
+%UPLUS  Unary plus for STRUCTUREDMATs
+
+h = A;
+end
+

--- a/@structuredmat/vertcat.m
+++ b/@structuredmat/vertcat.m
@@ -1,0 +1,10 @@
+function C = vertcat(varargin)
+%HORZCAT Vertical Concatenation for TOEPLITZMAT objects
+ 
+
+warning(['Using Naive implementation of VERTCAT.', ...
+           'This should be overloaded to take advantage of the structures!'], ...
+           class(A), class(B));
+C = [full(varargin{1});vertcat(varargin{2:end})];
+end
+

--- a/@toeplitzmat/constructor.m
+++ b/@toeplitzmat/constructor.m
@@ -50,15 +50,15 @@ function T = constructor(T, varargin)
 
 % ERROR (i): Too few args
 if(numel(varargin) == 0)
-    error('STRUCTMATS:TOEPLITZMAT:constructor:toofewargs', newline, ...
-            'Too few (0) arguments passed in to construct Toeplitz matrix');  
-        
+    error(['STRUCTMATS:TOEPLITZMAT:constructor:toofewargs', newline, ...
+       'Too few (0) arguments passed in to construct Toeplitz matrix']);  
+    
 % ERROR (ii)
 elseif( numel(varargin) > 2)
     error(['STRUCTMATS:TOEPLITZMAT:constructor:toomanyargs', ...
             newline, ...
             'Too many (%s) arguments passed in to construct Toeplitz matrix'],...
-            numel(varargin));
+            ""+numel(varargin));
 end
 
 
@@ -87,7 +87,7 @@ elseif( numel(varargin) > 2)
     error(['STRUCTMATS:TOEPLITZMAT:constructor:toomanyargs', ...
             newline, ...
             'Too many (%s) arguments passed in to construct Toeplitz matrix'],...
-            numel(varargin));
+            ""+numel(varargin));
 
 % CASE 2: |varargin| = 2
 else

--- a/@toeplitzmat/size.m
+++ b/@toeplitzmat/size.m
@@ -6,7 +6,7 @@ function s = size(T, dim)
     if(exist('dim','var'))
         if(dim <= 0 || dim >= 3)
             error(['TOEPLITZMAT:size:baddimension', ...
-                   'Cannot get size of toeplitzmatrix in dimension %s ',""+dim]);
+                   'Cannot get size of toeplitzmatrix in dimension %s '],""+dim);
         end
        s = s(dim);
     end

--- a/@toeplitzmat/toeplitzmat.m
+++ b/@toeplitzmat/toeplitzmat.m
@@ -26,8 +26,8 @@ classdef toeplitzmat < diagonalstructure
             
             % Error out if no arguments given
             if ( (nargin == 0) )
-                T.tc = [];
-                T.tr = [];
+                error(['STRUCTMATS:TOEPLITZMAT:constructor:toofewargs', newline, ...
+                   'Too few (0) arguments passed in to construct Toeplitz matrix']);  
             % Call the constructor, all the work is done here:
             else
                 T = constructor(T, varargin{:});

--- a/@toeplitzmat/toeplitzmat.m
+++ b/@toeplitzmat/toeplitzmat.m
@@ -26,8 +26,8 @@ classdef toeplitzmat < diagonalstructure
             
             % Error out if no arguments given
             if ( (nargin == 0) )
-                error(['STRUCTMATS:TOEPLITZMAT:constructor:toofewargs', newline, ...
-                   'Too few (0) arguments passed in to construct Toeplitz matrix']);  
+                T.tc = [];
+                T.tr = [];
             % Call the constructor, all the work is done here:
             else
                 T = constructor(T, varargin{:});

--- a/@vandermat/constructor.m
+++ b/@vandermat/constructor.m
@@ -1,0 +1,114 @@
+function V = constructor(V,varargin)
+%CONSTRUCTOR The main VANDERMAT constructor
+%   A Vandermonde matrix is determined by it's second column and total
+%   number of columns.
+%   As such, the input will be of the forms:
+%
+%   CASE 1: |varargin| = 1
+%       The input is a single vector. To be consistent with MATLAB, we
+%       interpret that the resulting Vandermonde matrix should be square
+%       and further that the given vector is the second column of the
+%       matrix.
+%
+%   Case 2: varargin is of size 2, containing a vector and a positive integer.
+%       In this case, we are given the second column and number of columns.
+%       The corresponding VANDERMAT is constructed, warning the user
+%       if it is singular..
+%
+%   ERROR CASES: There are a few different ways for a user to provide
+%               invalid input.
+%           (i): |varargin| = 0
+%                It does not quite make sense to have an empty constructor
+%                for VANDERMAT.
+%          (ii): |varargin| > 2
+%                A Vandermonde matrix is resolved by the two pieces of
+%                information we are stored (2nd column + # of columns), so
+%                there is nothing to do with 3+ inputs.
+%          (iii): Bad input types
+%                If the input type does not fit into one of the valid CASES
+%                outlined above, then we have no way to make sense of it.
+%                For instance, if a string is passed in, we cannot turn it
+%                into a VANDERMAT in a meaningful way.
+%
+%   Here is an example of constructing a toeplitzmat:
+%
+%   x = [1 2 3 4 5];
+%   n = 4;
+%   V = vandermat(x, n);
+%
+%   The code above creates a vandermat representing
+%       [1 1 1  1  ]
+%   V = [1 2 4  16 ]
+%       [1 3 9  27 ]
+%       [1 4 16 64 ]
+%       [1 5 25 125]
+%   For efficiency, we are storing only x and n.
+
+% ERROR (i): Too few args
+if(numel(varargin) == 0)
+    error(['STRUCTMATS:VANDERMAT:constructor:toofewargs', newline, ...
+       'Too few (0) arguments passed in to construct Vandermonde matrix']);  
+    
+% ERROR (ii)
+elseif( numel(varargin) > 2)
+    error(['STRUCTMATS:VANDERMAT:constructor:toomanyargs', ...
+            newline, ...
+            'Too many (%s) arguments passed in to construct Toeplitz matrix'],...
+            ""+numel(varargin));
+end
+
+% CASE 1: |varargin| = 1
+if( numel(varargin) == 1)
+    x = varargin{1};
+
+    % (a): Input is a numeric vector, create a square VANDERMAT
+    if( isvector(x) && (isnumeric(x) || islogical(x)))
+        if(size(x,2) > 1) % let's store x as a column vector
+            x = x.';
+        end
+        V.x = x;
+        V.n = size(x,1);
+    % ERROR (iii): Bad input type
+    else
+        error(['STRUCTMATS:VANDERMAT:constructor:badinput', ...
+            newline, ...
+            'Cannot create a vandermat out of single input of type %s'],...
+            class(x));
+    end
+
+% ERROR (ii): Too many inputs
+elseif( numel(varargin) > 2)
+    error(['STRUCTMATS:VANDERMAT:constructor:toomanyargs', ...
+            newline, ...
+            'Too many (%s) arguments passed in to construct Vandermonde matrix'],...
+            ""+numel(varargin));
+
+% CASE 2: |varargin| = 2
+else
+    % Get the second column and number of columns
+    x = varargin{1};
+    n = varargin{2};
+    
+    % ERROR (iv): Bad input types
+    if( ~isvector(x) )
+        error(['STRUCTMATS:VANDERMAT:constructor:badinput', ...
+                newline, ...
+                'The first input was not a vector.']);
+    elseif(n < 1 || mod(n,1)~=0 )
+        error(['STRUCTMATS:VANDERMAT:constructor:badinput', ...
+                newline, ...
+                'The second input must be a positive integer.']);
+    end
+        
+    % Transpose x to make sure it's a column.
+    if(size(x,2) > 1)
+        x = x.';
+    end
+    
+    % All is good - finish construction
+    V.x = x;
+    V.n = n;
+end
+
+end
+

--- a/@vandermat/full.m
+++ b/@vandermat/full.m
@@ -1,0 +1,7 @@
+function h = full(V)
+%FULL Casts VANDERMAT to dense matlab matrix
+
+h = V.x .^ (0:V.n);
+    
+end
+

--- a/@vandermat/ptwise_apply.m
+++ b/@vandermat/ptwise_apply.m
@@ -1,0 +1,9 @@
+function h = ptwise_apply(f, V1, V2)
+%PTWISE_APPLY Pointwise application of f to (V1,V2), where at least on of
+%   V1,V2 is a VANDERMAT. Unfortunately, I don't think there is much
+%   structure here to take advantage of. The only pointwise operation that
+%   retains vandermonde structure is V .^ a, where a is a scalar. This is
+%   handled in a separate file
+
+end
+

--- a/@vandermat/size.m
+++ b/@vandermat/size.m
@@ -1,0 +1,14 @@
+function s = size(V, dim)
+%SIZE for VANDERMAT objects
+%  returns the size of vandermonde matrix
+
+    s = [size(V.x, 1), V.n];
+    if(exist('dim','var'))
+        if(dim <= 0 || dim >= 3)
+            error(['VANDERMAT:size:baddimension', ...
+                   'Cannot get size of vandermat in dimension %s '],""+dim);
+        end
+       s = s(dim);
+    end
+    
+end

--- a/@vandermat/subsasgn.m
+++ b/@vandermat/subsasgn.m
@@ -1,0 +1,7 @@
+function A = subsasgn(V,S,B)
+%SUBSASGN Subassign for VANDERMAT objects.
+%   Naive temporary implementation below.
+
+A = builtin('subsref',V,S,B);
+end
+

--- a/@vandermat/subsref.m
+++ b/@vandermat/subsref.m
@@ -1,0 +1,7 @@
+function A = subsref(V,S)
+%SUBSREF Subreferencing for VANDERMAT objects.
+%   This is a temporary naive implemenation, and only . indexing works.
+
+A = builtin('subsref',V,S);
+end
+

--- a/@vandermat/vandermat.m
+++ b/@vandermat/vandermat.m
@@ -1,0 +1,60 @@
+classdef vandermat < structuredmat
+    %VANDERMAT class for representing Vandermonde matrices and computing
+    %   with them in an efficient manner.
+    %
+    %   A Vandermonde matrix is defined by its rows forming geometric 
+    %   progressions Vij = (V2j)^i. Here is a small example
+    %       [ 1  2  4   8  ]
+    %       [ 1  3  9   27 ]
+    %   V = [ 1  4  16  64 ]
+    %       [ 1  5  25  125]
+    %
+    %   If the Vandermonde matrix's dimension is known, then the second
+    %   column determines the rest of the matrix. For efficiency purposes,
+    %   this will be how we store the matrix.
+    % 
+    %   Vandermonde matrices are often used in problems invovling
+    %   polynomials. Indeed, given a vector of coefficients c, the
+    %   matrix-vector product Vc computes
+    %
+    %        [ 1  x1  (x1)^2] [c0]   [p(x1)]
+    %   Vc = [ 1  x2  (x2)^2] [c1] = [p(x2)] ,
+    %        [ 1  x3  (x2)^2] [c2]   [p(x3)]
+    %   where p(x) is the polynomial defined by
+    %       p(x) = c0 + c1*x + c2*x^2.
+    %   
+    %   The example above shows us that if V is invertible (which is
+    %   guaranteed by the xj's being distinct and V being square), we can
+    %   use Vandermonde matrices to solve for the coefficients of a
+    %   polynomial. Moreover, we can also use Vandermonde matrices to solve
+    %   for polynomial best-fits by instead using least-squares on
+    %   overdetermined system. It should be noted that a Vandermonde 
+    %   matrix need not be square.
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS CONSTRUCTOR:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    methods ( Access = public, Static = false )
+        function V = vandermat(varargin)
+            % The main vandermondemat constructor!
+            
+            % Error out if no arguments given
+            if ( (nargin == 0) )
+                error('Cannot construct a Vandermonde matrix with no inputs!')
+            % Call the constructor, all the work is done here:
+            else
+                V = constructor(V, varargin{:});
+            end       
+        end
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS PROPERTIES
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    properties (GetAccess = public, SetAccess = protected)
+        % 'x', 'n' are the second column and number of columns, respectively
+        x
+        n
+    end
+end
+

--- a/@vandermat/vandermat.m
+++ b/@vandermat/vandermat.m
@@ -36,8 +36,11 @@ classdef vandermat < structuredmat
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     methods ( Access = public, Static = false )
         function V = vandermat(varargin)
-            % The main vandermondemat constructor!
+            % The main vandermat constructor!
             
+            warning(['VANDERMAT is a work in progress! All operations are ',...
+                    'currently implemented via casting to a MATLAB matrix.'])
+
             % Error out if no arguments given
             if ( (nargin == 0) )
                 error('Cannot construct a Vandermonde matrix with no inputs!')

--- a/@vandermat/vandermat.m
+++ b/@vandermat/vandermat.m
@@ -38,7 +38,7 @@ classdef vandermat < structuredmat
         function V = vandermat(varargin)
             % The main vandermat constructor!
             
-            warning(['VANDERMAT is a work in progress! All operations are ',...
+            error(['VANDERMAT is a work in progress! All operations are ',...
                     'currently implemented via casting to a MATLAB matrix.'])
 
             % Error out if no arguments given

--- a/PointwiseTests/PointwiseTester.m
+++ b/PointwiseTests/PointwiseTester.m
@@ -1,6 +1,6 @@
 % TESTING DRIVER FOR POINTWISE OPERATIONS ON A STRUCTURED MATRIX
 
-% Test parameters
+% Test parametersC
 M = 500; N = 250;
 
 %% TEST toeplitzmat


### PR DESCRIPTION
I've added naïve implementations for most operations at the level of STRUCTUREDMAT. This will help speed up development of new structures, as the coder can instantiate their objects without implementing sophisticated algorithms for all the base operations.  All of these naïve overloads throw a warning to the tune of "This is currently a naïve implementation, please overload in a way that exploits structure!".

For instance, mtimes(A,B) with A as a STRUCTUREDMAT will return mtimes(full(A),full(B)). This is slow, will destroy any memory efficiency, and is clearly not closed. Nonetheless, I think this makes sense to do from and OOP standpoint.

There are 3 operations that the user must overloaded when creating their new class: full, subsref, and subasgn.

Also, I've added in the skeleton of VANDERMAT. It is functional, but it doesn't use any smart algorithms. Currently, it is being stored as a column vector and a positive integer (to denote the number of columns). This might change, and attempting to create a VANDERMAT errors out on the user (this can be disabled by commenting out the error line in the constructor).